### PR TITLE
Add a snap package (https://snapcraft.io)

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,17 @@
     "productName": "Perlotto",
     "mac": {
       "category": "public.app-category.music"
+    },
+    "linux": {
+      "target": "snap"
+    },
+    "snap": {
+      "plugs": [
+        "default"
+      ],
+      "after": [
+        "desktop-gtk2"
+      ]
     }
   },
   "repository": {
@@ -31,6 +42,6 @@
   },
   "devDependencies": {
     "electron": "^1.6.11",
-    "electron-builder": "^6.6.1"
+    "electron-builder": "^19.50.0"
   }
 }


### PR DESCRIPTION
Hi! I put together this PR to add a [snap](https://snapcraft.io) package. I've tested it on Ubuntu 17.10 and 16.04, but it should work just as well on Ubuntu 14.04, Linux Mint, Manjaro, Debian, OpenSUSE, Solus, etc.

If you merge and `npm run dist` it will create `dist/perlotto_0.4.0_amd64.snap`.

Copy this to a Linux system, [enable snap support](https://docs.snapcraft.io/core/install), then run:
`sudo snap install --dangerous perlotto_0.4.0_amd64.snap`

Run with `perlotto` or find it in the launcher.

If you create a developer account and push this to the Snap Store, it can be discovered and installed through GNOME Software and https://snapcraft.io/discover. To create the developer account, [sign up here](https://dashboard.snapcraft.io/dev/account/), then [register the "perlotto" name](https://dashboard.snapcraft.io/register-snap/?name=perlotto).

You'll need the `snapcraft` command to push the snap file to the store.
* If you're on a Mac, you can `brew install snapcraft`
* If you're on Linux, it's `sudo snap install --classic snapcraft`

Then you can push Perlotto out with:
`snapcraft push perlotto_0.4.0_amd64.snap --release stable`