### PR TITLE
LastFM window: Disable menu, make modal

### DIFF
--- a/lastfm.js
+++ b/lastfm.js
@@ -15,6 +15,7 @@ exports.api = lfm;
 
 var server;
 var lfmWindow;
+var mainWindow;
 
 var port = 4567;
 var host = 'http://127.0.0.1';
@@ -47,7 +48,8 @@ exports.stopServer = function() {
     server = null;
 };
 
-exports.init = function() {
+exports.init = function(mainWnd) {
+    mainWindow = mainWnd;
     sessionData = settings.get('lastfm');
 
     if (sessionData) {
@@ -84,6 +86,8 @@ exports.authorize = function(cb) {
     lfmWindow = new BrowserWindow({
         width: 600,
         height: 600,
+        parent: mainWindow,
+        modal: true,
     })
     lfmWindow.setMenu(null);
 

--- a/lastfm.js
+++ b/lastfm.js
@@ -85,6 +85,7 @@ exports.authorize = function(cb) {
         width: 600,
         height: 600,
     })
+    lfmWindow.setMenu(null);
 
     exports.startServer(function(token) {
         exports.stopServer();

--- a/main.js
+++ b/main.js
@@ -77,7 +77,7 @@ function createWindow () {
         lastfm.scrobble(arg);
     });
 
-    lastfm.init();
+    lastfm.init(mainWindow);
     updateMenu();
     initFilters();
 }


### PR DESCRIPTION
I found it kind of distracting the the LastFM window has the same menu bar as the main application. In fact, you do not need a menu for that window at all, so this PR removes the menu from the LastFM window. In addition it makes the window modal and attached to the main window, which provides a better experience on Linux (window does not vanish below the player).

I've tested the modification under Arch Linux + Gnome, but cannot tell whether there are implications on MacOS (shouldn't be TBH).